### PR TITLE
Fixed comparison of string literals

### DIFF
--- a/todo/commands/base.py
+++ b/todo/commands/base.py
@@ -60,7 +60,7 @@ class Command:
             sys.exit()
 
         titles = titles_input.split(',')
-        return [ title.strip() for title in titles if title is not '' ]
+        return [ title.strip() for title in titles if title != '' ]
 
 
     def cancel_command(self):


### PR DESCRIPTION
Fixed comparison made by "is not" as opposed to != as utilizing "is not" could result in unexpected behavior. Pyflakes flagged this bug with the warning message being:

`todo-cli/todo/commands/base.py:63:55: use ==/!= to compare constant literals (str, bytes, int, float, tuple)`